### PR TITLE
Rework PHP in home template to make it more readable.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,6 +6,19 @@
  * @subpackage Rotary
  * @since Rotary 1.0
  */
+
+
+$set_clubname = get_theme_mod( 'rotary_club_name', '' );
+$rotaryClubBefore = get_theme_mod( 'rotary_club_first', false);
+if ($rotaryClubBefore) {
+        if ($set_clubname) {
+                $clubname = "Rotary Club Of ".$set_clubname;
+        }
+} else {
+        if ($set_clubname) {
+                $clubname = $set_clubname." Rotary Club";
+        }
+}
 ?>
 
 	<footer id="footer" role="contentinfo">
@@ -13,8 +26,8 @@
 		
 		<section id="colophon">
 		<p class="alignleft"><?php echo _e( 'Web Design', 'rotary' ); ?>: <a href="http://www.carolinatorres.com/" target="_blank">Carolina Torres</a> <?php echo _e( 'Web Development', 'rotary' ); ?>: <a href="http://www.koolkatwebdesigns.com/" target="_blank">Merrill M. Mayer</a></p>
-		<p class="alignright">&copy; <?php echo date('Y'); ?> <a href="<?php  echo site_url();?>" target="_blank"><?php  echo get_theme_mod( 'rotary_club_name', '' );  ?>
-		</a>. <?php echo _e( 'All rights reserved', 'rotary' ); ?>.</p>
+		<p class="alignright">&copy; <?php echo date('Y'); ?> <a href="<?php  echo site_url();?>" target="_blank"><?php  echo $clubname;  ?></a>.
+		<?php echo _e( 'All rights reserved', 'rotary' ); ?>.</p>
 		<p id="twentyfive-tag" class="aligncenter"><?php echo _e( 'For assistance in deploying and hosting this website template for your club please contact our technical partners at TwentyFive', 'rotary' ); ?></p>
 		</section>		
 	</footer>

--- a/loop.php
+++ b/loop.php
@@ -13,7 +13,7 @@
 if (  $wp_query->max_num_pages > 1 ) :
 ?>
     <nav class="prevnext">
-        <div class="nav-previous">from loop<?php next_posts_link( __( '&lt; Older posts', 'Rotary' ) ); ?></div>
+        <div class="nav-previous"><?php next_posts_link( __( '&lt; Older posts', 'Rotary' ) ); ?></div>
         <div class="nav-next"><?php previous_posts_link( __( 'Newer posts &gt;', 'Rotary' ) ); ?></div>
     </nav>
 <?php 

--- a/tmpl-home.php
+++ b/tmpl-home.php
@@ -9,13 +9,11 @@
 
 get_header(); ?>
 
-<?php  if (get_theme_mod( 'rotary_slideshow', true )) {
+if (get_theme_mod( 'rotary_slideshow', true )) {
 	rotary_get_slideshow(); 
 } ?>
 	<div id="page">
-		<div id="content" role="main"
-		class="<?php  if ( get_theme_mod( 'rotary_home_sidebar', true )){ echo 'hassidebar-wide';} else{ echo 'fullwidth';} ?>"
-		>
+		<div id="content" role="main" class="<?php  if ( get_theme_mod( 'rotary_home_sidebar', true )){ echo 'hassidebar-wide';} else{ echo 'fullwidth';} ?>">
 		
 		<?php if ( have_posts() ) while ( have_posts() ) : the_post(); ?>
 		   <section class="homecontent">
@@ -33,4 +31,4 @@ get_header(); ?>
 	</footer>
 		
 	</div>
-<?php get_footer(); ?>
+<?php get_footer();


### PR DESCRIPTION
From loop debug code removed. Paul already mentioned this in an email.

Changed the footer to perform the same as the header with adding Rotary Club before or after the club's name.  Also tweaked the markup to remove between the name and the period in the copyright line.

The last one was me making it easier for me to read and dropping the last end tag in PHP as a way to avoid certain classes of errors and unintended whitespace in the final rendered page that can throw things off.

Git Commit Comment:
Remove "from loop" text from loop.php file (just distracting in display on site)
Altered Club Name display in footer to match that in header (Auto add Rotary Club of/Rotary Club based on whether it's to be added after or before name.
