### PR TITLE
Fixed missing <?php tag on homepage template causing broken slideshow

### DIFF
--- a/tmpl-home.php
+++ b/tmpl-home.php
@@ -9,7 +9,7 @@
 
 get_header(); ?>
 
-if (get_theme_mod( 'rotary_slideshow', true )) {
+<?php  if (get_theme_mod( 'rotary_slideshow', true )) {
 	rotary_get_slideshow(); 
 } ?>
 	<div id="page">


### PR DESCRIPTION
This tag seems to have been accidentally removed by previous commit
