### PR TITLE
Update assets.php to fix PHP7.2.9 related warning.

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -99,7 +99,7 @@ class Github_Theme_Upgrader extends Theme_Upgrader {
 		return $tmpfname;
 	}
 	
-	function download_package($package) {
+	function download_package($package, $check_signatures = true) {
 		/*
 			http://core.trac.wordpress.org/browser/trunk/wp-admin/includes/class-wp-upgrader.php?rev=17771#L108
 			changes:


### PR DESCRIPTION
Fixing warning notice that shows up under PHP 7.2.x. Warning: Declaration of Github_Theme_Upgrader::download_package($package) should be compatible with WP_Upgrader::download_package($package, $check_signatures = false) in /includes/assets.php on line 62